### PR TITLE
Add all CombineStatsGrowth + GetCombinePersonaStatGrowth function to APersonaStatusDraw

### DIFF
--- a/p3rpc.nativetypes.Interfaces/PublicAPI.Unshipped.txt
+++ b/p3rpc.nativetypes.Interfaces/PublicAPI.Unshipped.txt
@@ -394,6 +394,11 @@ p3rpc.nativetypes.Interfaces.APersonaStatusDraw.BaseLuckStat -> int
 p3rpc.nativetypes.Interfaces.APersonaStatusDraw.BaseMagicStat -> int
 p3rpc.nativetypes.Interfaces.APersonaStatusDraw.baseObj -> p3rpc.nativetypes.Interfaces.AUIDrawBaseActor
 p3rpc.nativetypes.Interfaces.APersonaStatusDraw.BaseStrengthStat -> int
+p3rpc.nativetypes.Interfaces.APersonaStatusDraw.CombineAgilityStatGrowth -> byte
+p3rpc.nativetypes.Interfaces.APersonaStatusDraw.CombineEnduranceStatGrowth -> byte
+p3rpc.nativetypes.Interfaces.APersonaStatusDraw.CombineLuckStatGrowth -> byte
+p3rpc.nativetypes.Interfaces.APersonaStatusDraw.CombineMagicStatGrowth -> byte
+p3rpc.nativetypes.Interfaces.APersonaStatusDraw.CombineStrengthStatGrowth -> byte
 p3rpc.nativetypes.Interfaces.APersonaStatusDraw.CurrentPersona -> p3rpc.nativetypes.Interfaces.FDatUnitPersonaEntry
 p3rpc.nativetypes.Interfaces.APersonaStatusDraw.Edit_AffinityCheck_Font_1_FadeIn_Delay -> int
 p3rpc.nativetypes.Interfaces.APersonaStatusDraw.Edit_AffinityCheck_Font_1_Move_Delay -> int
@@ -543,6 +548,7 @@ p3rpc.nativetypes.Interfaces.APersonaStatusDraw.Field5C4 -> float
 p3rpc.nativetypes.Interfaces.APersonaStatusDraw.Field7BC -> float
 p3rpc.nativetypes.Interfaces.APersonaStatusDraw.Field7C0 -> float
 p3rpc.nativetypes.Interfaces.APersonaStatusDraw.GetBasePersonaStat(int i) -> int
+p3rpc.nativetypes.Interfaces.APersonaStatusDraw.GetCombinePersonaStatGrowth(int i) -> byte
 p3rpc.nativetypes.Interfaces.APersonaStatusDraw.GetParamDisplayValueFrom(int i) -> float
 p3rpc.nativetypes.Interfaces.APersonaStatusDraw.GetParamDisplayValueTo(int i) -> float
 p3rpc.nativetypes.Interfaces.APersonaStatusDraw.IsMemoryCheckPersonaModel -> bool

--- a/p3rpc.nativetypes.Interfaces/Xrd777.cs
+++ b/p3rpc.nativetypes.Interfaces/Xrd777.cs
@@ -3916,6 +3916,11 @@ public unsafe struct APersonaStatusDraw
     [FieldOffset(0x0484)] public int Edit_LevelUp_SlideIn_Frame;
     [FieldOffset(0x0488)] public int Edit_LevelUp_Plate_FadeOut_Frame;
     [FieldOffset(0x48e)] public byte Field48E;
+    [FieldOffset(0x0598)] public byte CombineStrengthStatGrowth;
+    [FieldOffset(0x0599)] public byte CombineMagicStatGrowth;
+    [FieldOffset(0x059A)] public byte CombineEnduranceStatGrowth;
+    [FieldOffset(0x059B)] public byte CombineAgilityStatGrowth;
+    [FieldOffset(0x059C)] public byte CombineLuckStatGrowth;
     [FieldOffset(0x05A0)] public int Edit_SkillAdd_Next_Skill_Start_Delay;
     [FieldOffset(0x05A4)] public float Edit_SkillAdd_Next_Skill_Plate_Color_Fade_Wait;
     [FieldOffset(0x05A8)] public float Edit_SkillAdd_Next_Skill_Plate_Color_Fade_Time;
@@ -4050,6 +4055,7 @@ public unsafe struct APersonaStatusDraw
     public float GetParamDisplayValueFrom(int i) { fixed (APersonaStatusDraw* self = &this) { return *(float*)((nint)self + 0x45C + i * 4); } }
     public float GetParamDisplayValueTo(int i) { fixed (APersonaStatusDraw* self = &this) { return *(float*)((nint)self + 0x448 + i * 4); } }
     public void SetParamDisplayValueTo(int i, float v) { fixed (APersonaStatusDraw* self = &this) { *(float*)((nint)self + 0x448 + i * 4) = v; } }
+    public byte GetCombinePersonaStatGrowth(int i) { fixed (APersonaStatusDraw* self = &this) { return *(byte*)((nint)self + 0x598 + i); } }
 }
 
 // EVENTS


### PR DESCRIPTION
Added fields to APersonaStatusDraw:
- CombineStrengthStatGrowth
- CombineMagicStatGrowth
- CombineEnduranceStatGrowth
- CombineAgilityStatGrowth
- CombineLuckStatGrowth

Added function to retrieve any combine stat growth by index to APersonaStatusDraw:
- GetCombinePersonaStatGrowth

These fields are populated in Persona Status when selecting personas for fusion, they represent how much each stat will increase after the fusion + level up.

They are primarely used to trigger a glowing yellow effect on stat numbers that will be boosted.